### PR TITLE
chore: family maintenance sweep

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -133,6 +133,7 @@ jobs:
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
             -Dmaven.test.skip=true \
+            -DskipJsTests=true \
             -P gpg-sign \
             -P central-publishing \
             -Dcentral.timeout=3600 \
@@ -177,6 +178,7 @@ jobs:
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \
+            -DskipJsTests=true \
             -Dmaven.javadoc.skip=true \
             -Dmaven.source.skip=true \
             -P deploy-github-packages

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,6 @@ jobs:
     env:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR: true
       GITHUB_TOKEN: ${{ github.token }}  # Providing this prevents reaching the GitHub request limits
     steps:
       - name: 📄 Checkout the repository

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -81,6 +81,27 @@
         ]
       }
     },
+    "/api/disclaimer": {
+      "get": {
+        "operationId": "getDisclaimer",
+        "responses": {
+          "default": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "HTML help article"
+          }
+        },
+        "summary": "Returns the build-generated DISCLAIMER help article shown on the Usage Disclaimer page",
+        "tags": [
+          "Extension Information"
+        ]
+      }
+    },
     "/api/inspect/workitems": {
       "post": {
         "operationId": "inspectRequirements",

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,10 @@
              README.md -> about.html conversion fails CI instead of shipping an empty About page.
              Unset locally, the property does not resolve to a boolean and the plugin reads it as
              false, which is the parent's default. -->
-        <!--suppress UnresolvedMavenProperty -->
-        <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
+        <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
+             empty About page. markdown2html renders locally since 1.7.x - no GitHub API, no token -
+             so the same setting is right in CI, in a deploy job and on a developer machine. -->
+        <markdown2html-maven-plugin.failOnError>true</markdown2html-maven-plugin.failOnError>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,17 @@
             <version>${project.parent.version}</version>
         </dependency>
 
+        <!-- generic's test helpers: the JUnit extensions that give a test a Polarion context.
+             Note when building generic from source: -DskipTests still packages this test-jar,
+             -Dmaven.test.skip=true does not, and this build then fails resolving it. -->
+        <dependency>
+            <groupId>ch.sbb.polarion.extensions</groupId>
+            <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.10.1</version>
+        <version>15.11.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.requirements-inspector</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,6 @@
         <maven-jar-plugin.Require-Bundle.extension>com.polarion.platform.jobs</maven-jar-plugin.Require-Bundle.extension>
         <maven-jar-plugin.Require-Bundle>${maven-jar-plugin.Require-Bundle.common},${maven-jar-plugin.Require-Bundle.extension}</maven-jar-plugin.Require-Bundle>
 
-        <!-- The workflow sets MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR=true, so a broken
-             README.md -> about.html conversion fails CI instead of shipping an empty About page.
-             Unset locally, the property does not resolve to a boolean and the plugin reads it as
-             false, which is the parent's default. -->
         <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
              empty About page. markdown2html renders locally since 1.7.x - no GitHub API, no token -
              so the same setting is right in CI, in a deploy job and on a developer machine. -->
@@ -142,7 +138,6 @@
                 <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <outputFormat>JSON</outputFormat>
-                    <sortOutput>true</sortOutput>
                     <resourcePackages>
                         <package>ch.sbb.polarion.extension.generic.rest.controller.info</package>
                         <package>ch.sbb.polarion.extension.generic.rest.model</package>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
         -->
         <maven-jar-plugin.Require-Bundle.extension>com.polarion.platform.jobs</maven-jar-plugin.Require-Bundle.extension>
         <maven-jar-plugin.Require-Bundle>${maven-jar-plugin.Require-Bundle.common},${maven-jar-plugin.Require-Bundle.extension}</maven-jar-plugin.Require-Bundle>
+
+        <!-- The workflow sets MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR=true, so a broken
+             README.md -> about.html conversion fails CI instead of shipping an empty About page.
+             Unset locally, the property does not resolve to a boolean and the plugin reads it as
+             false, which is the parent's default. -->
+        <!--suppress UnresolvedMavenProperty -->
+        <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
     </properties>
 
     <dependencies>

--- a/ui/test/services.test.ts
+++ b/ui/test/services.test.ts
@@ -11,14 +11,14 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
   window.history.replaceState({}, '', origUrl);
-  document.cookie = 'je-test=; path=/; max-age=0';
+  document.cookie = 'requirements-inspector-test=; path=/; max-age=0';
 });
 
 describe('cookies', () => {
   it('round-trips a value and returns null for a missing one', () => {
-    expect(getCookie('je-test')).toBeNull();
-    setCookie('je-test', 'hello world');
-    expect(getCookie('je-test')).toBe('hello world');
+    expect(getCookie('requirements-inspector-test')).toBeNull();
+    setCookie('requirements-inspector-test', 'hello world');
+    expect(getCookie('requirements-inspector-test')).toBe('hello world');
   });
 });
 


### PR DESCRIPTION
### Proposed changes

Routine maintenance sweep across the extension family. This repository's share:

- ci: skip the UI suite in the deploy jobs
- build: let CI fail on a broken README conversion
- build: depend on generic's test-jar
- test: use this extension's own cookie name
- build: bump the generic parent to 15.11.0

The parent bump is the one change here with a runtime effect: the extension ships against generic 15.11.0, which adds the inherited `/disclaimer` endpoint (so `docs/openapi.json`, regenerated by the build, now documents `/api/disclaimer`) and pins `jakarta.annotation` to the API bundle, without which a filter's `@Priority` was ignored and the authentication and authorization filters ordered by `HashSet` iteration order - differently on each JVM start.

Nothing else touches runtime sources: the remaining commits change CI workflows, poms, tests and docs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
