### PR TITLE
build: switch to @sbb-polarion/react-sbb-polarion

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 # Requirements Inspector UI
 
-A React + Vite single-page app on [react-sbb-polarion](https://github.com/grigoriev/react-sbb-polarion)
+A React + Vite single-page app on [react-sbb-polarion](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion)
 (RSP). It replaces the legacy `about.jsp`, which was a two-line wrapper around generic's
 server-rendered About page. The whole page comes from RSP's shared `About` component; this app only
 feeds it the extension's REST hook, icon and REST-API URL.

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,7 +7,7 @@
     <!-- Baseline Polarion look. Served by Polarion in production; 404s harmlessly during `vite dev`. -->
     <link rel="stylesheet" href="/polarion/wiki/skins/sidecar/presentation.css" />
     <!-- Control tokens + searchable-dropdown / inputs / buttons / alerts CSS ship bundled in
-         @grigoriev/react-sbb-polarion (imported in main.tsx), not linked from generic. -->
+         @sbb-polarion/react-sbb-polarion (imported in main.tsx), not linked from generic. -->
     <!-- Markdown styling for the About page README help article (served by GenericUiServlet). -->
     <link rel="stylesheet" href="/polarion/requirements-inspector-app/ui/generic/css/github-markdown-light.css" />
   </head>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "requirements-inspector-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.2.0",
+        "@sbb-polarion/react-sbb-polarion": "^1.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -432,24 +432,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.2.0.tgz",
-      "integrity": "sha512-Yiuy22TWG5qWVJLYQx/b0FrMip/FJmfiGp6vUPcXN2JYILTmvuXTPK7vBTWbVOc8cobtnyPRtIx7h+IFn0JzmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "refractor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=24.0.0",
-        "npm": ">=11"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "sonner": "^2.0.7"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -855,6 +837,24 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sbb-polarion/react-sbb-polarion": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sbb-polarion/react-sbb-polarion/-/react-sbb-polarion-1.0.0.tgz",
+      "integrity": "sha512-hTk4oewJvkUL02blEktAJXMc4IiyftaG6fH4+viNP5wdH12mJxKMfHZAmB4xA50vnvFrfdZDhLrxPP/+fC6VwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=11"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "sonner": "^2.0.7"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.2.0",
+    "@sbb-polarion/react-sbb-polarion": "^1.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -102,4 +102,4 @@
 }
 
 /* The About page (and its .markdown-body README article headings) is the shared
-   @grigoriev/react-sbb-polarion component; its styles ship in the lib's bundled style.css. */
+   @sbb-polarion/react-sbb-polarion component; its styles ship in the lib's bundled style.css. */

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { configureGenericModules } from '@grigoriev/react-sbb-polarion';
-import '@grigoriev/react-sbb-polarion/style.css';
+import { configureGenericModules } from '@sbb-polarion/react-sbb-polarion';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import App from './App';
 import './App.css';
 

--- a/ui/src/pages/About.tsx
+++ b/ui/src/pages/About.tsx
@@ -1,4 +1,4 @@
-import { About } from '@grigoriev/react-sbb-polarion';
+import { About } from '@sbb-polarion/react-sbb-polarion';
 import appIcon from '../assets/app-icon.svg';
 import useRemote from '../services/useRemote';
 

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { FEATURES } from '../features';
 import { getCookie, setCookie } from '../services/cookies';
 import { fetchProjects } from '../services/projects';

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -9,6 +9,6 @@
 // The Polarion-served stylesheets linked in index.html (presentation.css, github-markdown-light.css)
 // are not bundled and are not loaded here; they are baseline chrome / help-article styling. Also
 // registers the jest-dom matchers.
-import '@grigoriev/react-sbb-polarion/style.css';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import '@testing-library/jest-dom/vitest';
 import '../src/App.css';

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const polarionUrl = env.VITE_BASE_URL || 'http://localhost';
 
-  // @grigoriev/react-sbb-polarion is linked via a `file:` dependency, which npm
+  // @sbb-polarion/react-sbb-polarion is linked via a `file:` dependency, which npm
   // symlinks into node_modules together with its own dev copy of React. Dedupe so the app and the
   // linked library resolve to this app's single React instance (avoids the dual-React "invalid hook
   // call"). Harmless once the package is consumed from a registry instead of a symlink.

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       'react/jsx-runtime',
       'react/jsx-dev-runtime',
       'vitest-browser-react',
-      '@grigoriev/react-sbb-polarion',
+      '@sbb-polarion/react-sbb-polarion',
     ],
   },
   test: {


### PR DESCRIPTION
The shared React library moved from a personal npm scope to the SBB organization and released 1.0.0:
`@grigoriev/react-sbb-polarion` is now
[`@sbb-polarion/react-sbb-polarion`](https://www.npmjs.com/package/@sbb-polarion/react-sbb-polarion).

Only the package name changes. 1.0.0 is 0.2.1 with a different name - the major is there because the
rename itself is the breaking change, not because the API moved. So this is the dependency, its version
range and every import, nothing else.

The stale `github.com/grigoriev/react-sbb-polarion` links follow the repository to
`SchweizerischeBundesbahnen`. `io.github.grigoriev` in `pom.xml` and `grigoriev/pre-commit-*` in
`.pre-commit-config.yaml` are unrelated projects and are left alone.
