### PR TITLE
docs: drop generic-UI from the dev proxy description

### DIFF
--- a/ui/.env.local.template
+++ b/ui/.env.local.template
@@ -1,6 +1,6 @@
 # Copy to .env.local and fill in for `npm run dev`.
 
-# The Polarion instance the dev server proxies REST + generic-UI + panel-CSS requests to.
+# The Polarion instance the dev server proxies REST + panel-CSS requests to.
 VITE_BASE_URL=https://your-polarion-host
 
 # Optional: a Polarion personal access token. When set, useRemote switches to the token-authenticated


### PR DESCRIPTION
Follow-up to the 2.0.0 upgrade, from a review finding on
[interceptor-manager#238](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.interceptor-manager/pull/238).

That upgrade removed the `/ui/generic` dev proxy entry - nothing requests the path once the library
bundles the dropdown factories and the markdown stylesheet - but left the template describing it:

```diff
-# The Polarion instance the dev server proxies REST + generic-UI + panel-CSS requests to.
+# The Polarion instance the dev server proxies REST + panel-CSS requests to.
```

`panel-CSS` stays: that is what the `/polarion/ria` entry still forwards. `presentation.css` is
deliberately unproxied and 404s harmlessly during `vite dev`, so it is not part of the list either way.

Comment only - `.env.local.template` is copied to `.env.local`, where just the `VITE_BASE_URL` value
matters, so nothing behaves differently. The cost of leaving it is a reader inferring a proxy entry that
is not there.
