### PR TITLE
build: move to react-sbb-polarion 2.0.2

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "requirements-inspector-app",
       "version": "1.0.0",
       "dependencies": {
-        "@sbb-polarion/react-sbb-polarion": "^2.0.1",
+        "@sbb-polarion/react-sbb-polarion": "^2.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -856,9 +856,9 @@
       "license": "MIT"
     },
     "node_modules/@sbb-polarion/react-sbb-polarion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@sbb-polarion/react-sbb-polarion/-/react-sbb-polarion-2.0.1.tgz",
-      "integrity": "sha512-Z49v0eB2s4+RIlFevvN57vfs5k/TRcTur0NQ6QYL1o14ag7SxEBRNiMSQ6qfre5t++OfAKEQTVeka/pEbeOQ2w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sbb-polarion/react-sbb-polarion/-/react-sbb-polarion-2.0.2.tgz",
+      "integrity": "sha512-xmuusRQOoAuMXDyiDdGA/VjeB2+sPbRLNCxRuoDki+rrBHMPA6GU44l24YVKip56LLFrs4oXcnpdDcEF4nJS8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "refractor": "^5.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@sbb-polarion/react-sbb-polarion": "^2.0.1",
+    "@sbb-polarion/react-sbb-polarion": "^2.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
### Proposed changes

Moves the UI to `@sbb-polarion/react-sbb-polarion` 2.0.2.

2.0.2 restores generic's marking of a named setting that is inherited from a broader scope, in the
configuration selector of the administration pages: the name in normal weight with a small italic
`global` on the right edge and the settings of the current scope in bold, the way
`configurations.css` marked them before generic's v15.2 dropdown rewrite. Until now the React
selector appended an `(inherited)` suffix to the name instead.

Lockfile and the caret range only - no source change in this repository.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation

### Tests

Full UI suite in the pinned Playwright Docker image (`npm --prefix ui run test:docker`) - all passed,
no reference screenshot changed.
